### PR TITLE
remove zope

### DIFF
--- a/certbot_dns_dnspod/dns_dnspod.py
+++ b/certbot_dns_dnspod/dns_dnspod.py
@@ -1,13 +1,10 @@
 """DNS Authenticator for DNSPod DNS."""
 import logging
 
-import zope.interface
-
 from requests.exceptions import HTTPError
 from lexicon.providers import dnspod
 
 from certbot import errors
-from certbot import interfaces
 from certbot.plugins import dns_common
 from certbot.plugins import dns_common_lexicon
 
@@ -16,8 +13,6 @@ logger = logging.getLogger(__name__)
 ACCOUNT_URL = 'https://www.dnspod.cn/console/user/security'
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for DNSPod DNS
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ install_requires = [
     'dns-lexicon',
     'mock',
     'setuptools',
-    'zope.interface',
 ]
 
 docs_extras = [

--- a/snap-requirements.txt
+++ b/snap-requirements.txt
@@ -2,4 +2,3 @@ acme>=0.21.1
 dns-lexicon>=3.8.3
 mock>=4.0.3
 setuptools>=59.2.0
-zope.interface>=5.4.0


### PR DESCRIPTION
zope has been deprecated since the release of Certbot 1.19.0 and the referenced interfaces will be removed in an upcoming version of Certbot.