### PR TITLE
获取域名 id 时，不存在的域名返回错误信息不匹配，导致判断错误抛异常 

### DIFF
--- a/certbot_dns_dnspod/dns_dnspod.py
+++ b/certbot_dns_dnspod/dns_dnspod.py
@@ -123,6 +123,6 @@ class _DNSPodLexiconClient(dns_common_lexicon.LexiconClient):
                                   .format(domain_name, e, ' ({0})'.format(hint) if hint else ''))
 
     def _handle_general_error(self, e, domain_name):
-        if not (str(e).startswith('Domain name invalid') or str(e).find('当前域名有误') >= 0):
+        if not (str(e).startswith('Domain name invalid') or str(e).find('当前域名未添加') >= 0):
             return errors.PluginError('Unexpected error determining zone identifier for {0}: {1}'
                                       .format(domain_name, e))


### PR DESCRIPTION
腾讯又更新了相关术语，导致续期失效