### PR TITLE
fix: resolve incompatibility with certbot 3.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,26 @@
 .DS_Store
 .vs
+__pycache__
+
+# Python build artifacts
+*.pyc
+__pycache__/
+*.egg-info/
+dist/
+build/
+
+# Virtual environment
+venv/
+.venv/
+
+# IDE files
+.vscode/
+.idea/
+
+# Test cache
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Documentation build
+docs/_build/

--- a/certbot_dns_dnspod/dns_dnspod.py
+++ b/certbot_dns_dnspod/dns_dnspod.py
@@ -118,6 +118,9 @@ class _DNSPodLexiconClient(dns_common_lexicon.LexiconClient):
                                   .format(domain_name, e, ' ({0})'.format(hint) if hint else ''))
 
     def _handle_general_error(self, e, domain_name):
-        if not (str(e).startswith('Domain name invalid') or str(e).find('当前域名未添加') >= 0):
-            return errors.PluginError('Unexpected error determining zone identifier for {0}: {1}'
-                                      .format(domain_name, e))
+        # Only return None for "Domain name invalid" or "Domain not found" errors
+        # to continue trying other domain_name guesses
+        if str(e) == 'No domain found' or str(e).startswith('Domain name invalid') or str(e).find('当前域名未添加') >= 0:
+            return None
+        return errors.PluginError('Unexpected error determining zone identifier for {0}: {1}'
+                                  .format(domain_name, e))

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,16 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-version = '0.24.2'
+version = '0.25.0'
 
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
 install_requires = [
-    'acme>=0.21.1',
-    'certbot>=0.21.1',
-    'dns-lexicon',
-    'mock',
-    'setuptools',
+    'acme>=2.12.0',
+    'certbot>=2.12.0',
+    'dns-lexicon>=3.8.3',
+    'mock>=4.0.3',
+    'setuptools>=59.2.0',
 ]
 
 docs_extras = [
@@ -29,7 +29,7 @@ setup(
     author="Certbot Project",
     author_email='tengattack@gmail.com',
     license='Apache License 2.0',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.8',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Plugins',
@@ -37,12 +37,12 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Security',
         'Topic :: System :: Installation/Setup',

--- a/snap-requirements.txt
+++ b/snap-requirements.txt
@@ -1,4 +1,5 @@
-acme>=0.21.1
+acme>=2.12.0
+certbot>=2.12.0
 dns-lexicon>=3.8.3
 mock>=4.0.3
 setuptools>=59.2.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,12 +1,12 @@
 name: certbot-dns-dnspod
 summary: DNSPod DNS Authenticator plugin for Certbot
-version: '0.24.2'
+version: '0.25.0'
 description: A certbot dns plugin to obtain certificates using dnspod. For information on how to set up, go to the GitHub page.
 website: https://github.com/tengattack/certbot-dns-dnspod
 license: Apache-2.0
 confinement: strict
 grade: stable
-base: core20
+base: core24
 adopt-info: certbot-dns-dnspod
 architectures:
   - build-on: arm64
@@ -30,6 +30,10 @@ parts:
       - libssl-dev
       - libffi-dev
       - python3-dev
+    python-packages:
+      - pip
+      - wheel
+      - setuptools
   certbot-metadata:
     plugin: dump
     source: .
@@ -43,7 +47,7 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.8/site-packages
+      - $SNAP/lib/python3.12/site-packages
 
 plugs:
   certbot-metadata:


### PR DESCRIPTION
This plugin is literally not working due to

![image](https://github.com/user-attachments/assets/3c394a4e-8045-47e2-b665-96a5a6f18312)

This pull request resolves this problem

also resolve https://github.com/tengattack/certbot-dns-dnspod/issues/20

![image](https://github.com/user-attachments/assets/e3cec7d7-ca34-483b-b5af-fd29025c63b2)
